### PR TITLE
Refactor: 구조 변경 - 게임 상태 로직을 컨트롤러에서 모델로 이동

### DIFF
--- a/src/Models/BaseballGame.js
+++ b/src/Models/BaseballGame.js
@@ -1,12 +1,35 @@
-import { GAME_CONSTANTS } from "../utils/constants.js";
+import {
+  GAME_CONSTANTS,
+  GAME_STATES,
+  USER_COMMANDS,
+} from "../utils/constants.js";
 import { gameUtils } from "../utils/gameUtils.js";
 
 const { MIN_NUMBER, MAX_NUMBER, ANSWER_LENGTH } = GAME_CONSTANTS;
+const { PLAYING, COMMAND, QUIT } = GAME_STATES;
 
 export default class BaseballGame {
   #answer;
+  #gameState;
 
-  setNewAnswer() {
+  constructor() {
+    this.#startNewGame();
+  }
+
+  #setGameState(state) {
+    this.#gameState = state;
+  }
+
+  #startNewGame() {
+    this.#setNewAnswer();
+    this.#setGameState(PLAYING);
+  }
+
+  #quitGame() {
+    this.#setGameState(QUIT);
+  }
+
+  #setNewAnswer() {
     this.#answer = gameUtils.generateAnswer(
       MIN_NUMBER,
       MAX_NUMBER,
@@ -14,19 +37,38 @@ export default class BaseballGame {
     );
   }
 
-  calculateBallStrikeScore(userInput) {
-    let strike = 0;
-    let ball = 0;
+  handleUserPitches(userInput) {
     const pitchedBallNumbers = userInput.split("").map(Number);
-    for (let i = 0; i < pitchedBallNumbers.length; i += 1) {
-      if (this.#answer[i] === pitchedBallNumbers[i]) {
-        strike += 1;
-        continue;
-      }
-      if (this.#answer.includes(pitchedBallNumbers[i])) {
-        ball += 1;
-      }
-    }
+    const [ball, strike] = gameUtils.calculateBallStrikeScore(
+      this.#answer,
+      pitchedBallNumbers
+    );
+    this.#updateGameStateAfterPitch(strike);
     return [ball, strike];
+  }
+
+  handleUserCommand(input) {
+    switch (input) {
+      case USER_COMMANDS.RESTART:
+        this.#startNewGame();
+        break;
+      case USER_COMMANDS.QUIT:
+        this.#quitGame();
+        break;
+    }
+  }
+
+  #updateGameStateAfterPitch(strike) {
+    if (strike === GAME_CONSTANTS.STRIKE_OUT_COUNT) {
+      this.#setGameState(COMMAND);
+    }
+  }
+
+  isInCommandPhase() {
+    return this.#gameState === COMMAND;
+  }
+
+  isGameEnded() {
+    return this.#gameState === QUIT;
   }
 }

--- a/src/utils/gameUtils.js
+++ b/src/utils/gameUtils.js
@@ -11,4 +11,18 @@ export const gameUtils = {
 
     return [...answer];
   },
+  calculateBallStrikeScore(answer, pitches) {
+    let ball = 0;
+    let strike = 0;
+    for (let i = 0; i < pitches.length; i += 1) {
+      if (answer[i] === pitches[i]) {
+        strike += 1;
+        continue;
+      }
+      if (answer.includes(pitches[i])) {
+        ball += 1;
+      }
+    }
+    return [ball, strike];
+  },
 };


### PR DESCRIPTION
- 게임 상태에 따라 반복문을 실행하고, 조건에 맞추어 게임 상태를 변경하는 컨트롤러의 로직을 수정하여, 게임 상태 변경을 모델(BaseballGame)에서 수행하도록 하고 컨트롤러는 단순히 조건에 따른 흐름만 관리하게끔 함으로써, 컨트롤러가 게임 내부 로직에 직접 관여하지 않게끔 책임을 분리한다.
- 정답 배열과 입력값 배열을 비교하여 ball, strike 점수를 계산하고 반환하는 함수를 gameUtils로 분리한다.
- readAndProcessNumbers를 readNumbersInput, processNumbers로 나누어 책임을 분리한다. command에도 같은 수정사항을 적용한다.
- 그 외 함수, 변수명 변경